### PR TITLE
frontend: save NPM_TOKEN in homedir

### DIFF
--- a/src/yukon/backend/src/api/version.py
+++ b/src/yukon/backend/src/api/version.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT License.
 #
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __license__ = 'MIT'

--- a/src/yukon/frontend/package.json
+++ b/src/yukon/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yukon_frontend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "UAVCAN Yukon Vue.js frontend",
   "author": "UAVCAN Development Team <uavcan-maintainers@googlegroups.com>",
   "keywords": [

--- a/tox.ini
+++ b/tox.ini
@@ -335,9 +335,9 @@ deps =
 changedir={toxinidir}/src/yukon/frontend
 
 commands =
-    echo "//registry.npmjs.org/:_authToken={env:NPM_TOKEN:}" > {toxinidir}/src/yukon/frontend/.npmrc
+    echo "//registry.npmjs.org/:_authToken={env:NPM_TOKEN:}" > {homedir}/.npmrc
     npm publish
-    rm -rf .npmrc
+    rm -rf {homedir}/.npmrc
 
 
 [testenv:local]


### PR DESCRIPTION
Seems like the `NPM_TOKEN` is not set or not saved in the correct dir (https://buildkite.com/uavcan/yukon-release/builds/200#0a2c80fd-34a3-4238-83ca-ac8fce2a2d77/95-423). This aims to save it in the $HOME directory, as pointed on the npm docs.