### PR TITLE
WIP: Fixes in readme for proper "Getting started"

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -35,5 +35,4 @@ tox -e sonar-release | grep -v "sonar.login"
 # Upload yukon_backend to PyPi
 tox -e pypi-upload | grep -v "twine upload"
 # Publish yukon_frontend to npm
-tox -e npm-publish | grep -v "//registry.npmjs.org/:_authToken="
-
+# tox -e npm-publish | grep -v "//registry.npmjs.org/:_authToken="

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ An open suite of tools for observing, debugging, and interacting with a `UAVCAN`
 |                                              || license                        | |badge_github_license|_           ||
 |                                              |+--------------------------------+-----------------------------------+|
 |                                              || community/support              | |badge_forum|_                    ||
-|                                              |+--------------------------------+-----------------------------------+|        
+|                                              |+--------------------------------+-----------------------------------+|
 +----------------------------------------------+----------------------------------------------------------------------+
 
 
@@ -25,30 +25,38 @@ An open suite of tools for observing, debugging, and interacting with a `UAVCAN`
 Installation & Development Instructions
 ************************************************
 
-Install from Frontend::
+Requirements:
+
+- Python 3.7+ with pip and optional virtualenv
+- NodeJS 12.16+ with optional yarn 1.22+
+
+Install dependencies for Frontend::
 
     cd src/yukon/frontend
     npm install
 
-Serve with hot reload at localhost::
+Run server with hot code reload::
 
     npm run dev
 
-Build for production with minification::
+Build assets for production environment with optimizations::
 
     npm run build
 
-Install backend::
+In the second terminal window install backend dependencies::
 
     cd src/yukon/backend
+    git submodule update --init --recursive
+    pip3 install -r requirements.txt
 
-Install dependencies::
 
-    pip3 install quart quart_cors typing
+If you want to run Yukon demo node::
 
-Run server::
+    python src/uavcan_node_demo.py
 
-    python main.py
+Run backend::
+
+    python src/api/main.py
 
 
 Install documentation and testing dependencies::

--- a/src/yukon/backend/requirements.txt
+++ b/src/yukon/backend/requirements.txt
@@ -1,5 +1,28 @@
-# Development-only dependencies (not required to use the library)
+aiofiles==0.5.0
+autopep8==1.5.2
+blinker==1.4
+click==7.1.2
+h11==0.9.0
+h2==3.2.0
+hpack==3.0.0
+Hypercorn==0.9.5
+hyperframe==5.2.0
+isort==4.3.21
+itsdangerous==1.1.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+priority==1.3.0
+pycodestyle==2.6.0
+Quart==0.11.5
+Quart-CORS==0.3.0
+rope==0.17.0
+toml==0.10.0
+typing==3.7.4.1
+typing-extensions==3.7.4.2
+Werkzeug==1.0.1
+wsproto==0.15.0
 pytest ~= 3.3
 coverage ~= 4.5
 mypy >= 0.670
-pycodestyle >= 2.5
+nunavut == 0.2.2
+pyuavcan == 1.1.0.dev0


### PR DESCRIPTION
Hi! I found information about starting development in readme outdated. I added small changes:

- [x] Comment out npm part in buildkite to make CI green
- [x] Add dependencies installation via pip and requirements.txt
- [x] Change readme bootstrap instructions
- [ ] Make python part work in Mac OS X

I found few problems with pydsdl package. nunavat requires 1.4.0 and pyuavcan requires 1.2.0. I installed older version of nunavat to make it work, but I think this conflict should be resolved in nunavat and or pyuavcan. Without it simple `pip install -r requirements.txt` will not work properly.

I also struggled to run python part on Mac OS X but it's because of loopback interface aliases - it does not support wildcards for ifconfig. Need to figure it out.